### PR TITLE
Add newsletter and events management specs; refactor test fixtures

### DIFF
--- a/docs/specs/L1.md
+++ b/docs/specs/L1.md
@@ -43,3 +43,8 @@ The public site shall provide full-text search over published articles, modelled
 **Status:** Draft
 
 The system shall provide newsletter authoring, publishing, and management capabilities. Authenticated users shall be able to create, edit, and send newsletters to subscribers. The public site shall allow anonymous visitors to sign up for the newsletter by providing their email address, confirm their subscription through a double opt-in flow, and unsubscribe at any time. Sent newsletters shall be viewable in a public web archive.
+
+## L1-015: Events
+**Status:** Draft
+
+The system shall allow the blog author to create, edit, publish, unpublish, and delete speaking events through the back office. Published events shall be displayed to anonymous visitors on the public site, organized by upcoming and past dates, with a detail page for each event.

--- a/docs/specs/L2.md
+++ b/docs/specs/L2.md
@@ -806,3 +806,98 @@ The public site shall provide a web-accessible archive of sent newsletters. Each
 2. Given a sent newsletter, when an anonymous user visits its unique URL, then the newsletter content shall be rendered as a readable HTML page.
 3. Given a draft newsletter, when an anonymous user attempts to access it by URL, then the system shall return a 404 Not Found.
 4. Given more sent newsletters exist than fit on one page, when the user navigates to the next page, then they shall see the next set of newsletters without duplicates.
+
+---
+
+## L2-064: Create Event
+**Status:** Draft
+**Traces to:** L1-015
+
+An authenticated user shall be able to create a new speaking event by providing a title, description, start date, optional end date, location, and optional external URL linking to the event page. The system shall generate a URL-safe slug from the title. The event shall default to unpublished (draft) status.
+
+**Acceptance Criteria:**
+1. Given an authenticated user, when they submit a valid event with title, description, start date, and location, then the event shall be persisted with a generated slug and `published = false`.
+2. Given an authenticated user, when they submit an event with a title that generates a slug already in use, then the system shall return a 409 Conflict response.
+3. Given an authenticated user, when they submit an event missing the title, start date, or location, then the system shall return a 400 Bad Request with field-level validation errors.
+4. Given an unauthenticated request, when they attempt to create an event, then the system shall return a 401 Unauthorized response.
+
+---
+
+## L2-065: Edit Event
+**Status:** Draft
+**Traces to:** L1-015
+
+An authenticated user shall be able to update any field of an existing event (title, description, start date, end date, location, external URL, published status). Updating the title shall regenerate the slug.
+
+**Acceptance Criteria:**
+1. Given an authenticated user and an existing event, when they update the title, then the slug shall be regenerated from the new title.
+2. Given an authenticated user, when they update a title that generates a slug already in use by a different event, then the system shall return a 409 Conflict response.
+3. Given an authenticated user, when they update an event with valid data, then all changed fields shall be persisted and unchanged fields shall remain intact.
+4. Given an authenticated user, when they update an event with an empty title, then the system shall return a 400 Bad Request.
+5. Given an authenticated user, when they update a non-existent event ID, then the system shall return a 404 Not Found.
+
+---
+
+## L2-066: Delete Event
+**Status:** Draft
+**Traces to:** L1-015
+
+An authenticated user shall be able to permanently delete an event. Deletion shall remove the event from the system.
+
+**Acceptance Criteria:**
+1. Given an authenticated user and an existing event, when they delete it, then the event shall no longer be retrievable via API or public site.
+2. Given an authenticated user, when they delete a non-existent event, then the system shall return 404 Not Found.
+3. Given an unauthenticated request, when they attempt to delete an event, then the system shall return 401 Unauthorized.
+
+---
+
+## L2-067: List Events in Back Office
+**Status:** Draft
+**Traces to:** L1-015
+
+The back-office shall display a paginated list of all events ordered by start date descending. The list shall include both published and unpublished events and show each event's title, start date, location, and published status.
+
+**Acceptance Criteria:**
+1. Given an authenticated user, when they navigate to the events management page, then all events shall be listed in descending start-date order with title, start date, location, and published status visible.
+2. Given more events than fit on a single page, when the user views the event list, then pagination controls shall allow navigating between pages.
+3. Given an unauthenticated request, when they attempt to access the events management page, then the system shall return 401 Unauthorized.
+
+---
+
+## L2-068: Publish and Unpublish Event
+**Status:** Draft
+**Traces to:** L1-015
+
+An authenticated user shall be able to publish a draft event (setting `published = true`) and unpublish a published event (setting `published = false`). Only published events shall appear on the public site.
+
+**Acceptance Criteria:**
+1. Given an authenticated user and a draft event, when they publish it, then `published` shall be `true` and the event shall become visible on the public site.
+2. Given an authenticated user and a published event, when they unpublish it, then `published` shall be `false` and the event shall no longer be visible on the public site.
+3. Given an unauthenticated request, when they attempt to publish or unpublish an event, then the system shall return 401 Unauthorized.
+
+---
+
+## L2-069: Public Events Display
+**Status:** Draft
+**Traces to:** L1-015
+
+The public site shall present published events on a dedicated events page accessible at `/events`. Events shall be separated into upcoming and past sections based on the event start date relative to the current date. Upcoming events shall be ordered by start date ascending (soonest first). Past events shall be ordered by start date descending (most recent first).
+
+**Acceptance Criteria:**
+1. Given published events exist with future start dates, when an anonymous visitor navigates to `/events`, then the upcoming section shall list those events in ascending start-date order.
+2. Given published events exist with past start dates, when an anonymous visitor navigates to `/events`, then the past section shall list those events in descending start-date order.
+3. Given no published events exist, when an anonymous visitor navigates to `/events`, then the page shall display an appropriate empty state message.
+4. Given a mix of published and unpublished events, when an anonymous visitor navigates to `/events`, then only published events shall be displayed.
+
+---
+
+## L2-070: Public Event Detail
+**Status:** Draft
+**Traces to:** L1-015
+
+The public site shall display a detail page for each published event at `/events/{slug}`. The detail page shall show the event title, description, start date, end date (if provided), location, and a link to the external event URL (if provided).
+
+**Acceptance Criteria:**
+1. Given a published event with a slug, when an anonymous visitor navigates to `/events/{slug}`, then the full event details shall be displayed including title, description, start date, location, and external URL (if present).
+2. Given an unpublished event, when an anonymous visitor navigates to its slug URL, then the system shall return 404 Not Found.
+3. Given a non-existent slug, when an anonymous visitor navigates to `/events/{slug}`, then the system shall return 404 Not Found.


### PR DESCRIPTION
## Summary
This PR adds comprehensive L2 specification documents for newsletter subscription management and speaking events features, refactors Playwright test fixtures to use a shared authenticated context, and makes targeted UI/styling improvements across the public and admin interfaces.

## Key Changes

### Documentation
- **Newsletter Features (L2-054 to L2-056)**: Added specs for subscription sign-up with double opt-in, confirmation flow with 48-hour token expiry, and one-click unsubscribe via email headers
- **Newsletter Management (L2-057 to L2-063)**: Added specs for authenticated users to create, edit, delete, and send newsletters; back-office subscriber management; and public newsletter archive
- **Events Management (L2-064 to L2-069)**: Added specs for authenticated users to create, edit, delete, and publish speaking events with slug generation; back-office event listing; and public event archive
- **L1 Requirements**: Updated L1.md to reference new newsletter (L1-014) and events (L1-015) capabilities

### Test Infrastructure
- **Fixture Refactoring**: Consolidated authenticated context creation into a shared `authenticatedPage` fixture in `base.fixture.ts` to reduce duplication and improve maintainability
- **Test Updates**: Updated all article management tests to use the new fixture pattern, removing redundant context creation and simplifying test setup
- **API Test Improvements**: Refactored error response and pagination API tests to use centralized token retrieval and consistent API URL handling

### UI/Styling Refinements
- **Layout Adjustments**: Removed bottom padding from `.articles-section` across all breakpoints for consistent spacing
- **Border Radius**: Changed `.empty-state` border-radius from `var(--radius-md)` to `var(--radius-sm)` for consistency
- **Search Page**: Updated search hero bar height and padding for tablet/mobile breakpoints; adjusted search content padding
- **Article Detail**: Expanded responsive typography and spacing rules for better readability across breakpoints
- **Admin Layout**: Minor gap adjustment in header (12px → 10px)
- **Footer Styling**: Added explicit padding rules to Feed and NotFound pages to ensure consistent footer spacing
- **Login Page**: Minor styling adjustments to login brand layout

### Test Assets
- Added fixture files for digital asset upload testing: `document.txt`, `image-as.txt`, and `oversized.jpg`

### Configuration
- Updated site configuration reference in Index.cshtml from `Site:SiteName` to `Site:AuthorName`
- Added inline padding override to article list page content container

## Implementation Details
- All new L2 specs follow the established ATDD pattern with clear acceptance criteria
- Newsletter tokens expire after 48 hours; subscriptions default to pending/unconfirmed status
- Events support slug generation from titles with duplicate detection
- Test fixture consolidation reduces code duplication while maintaining test isolation through browser context management

https://claude.ai/code/session_011fnewWo3A2CFfvSsYKYPZT