### PR TITLE
Add event management specifications (L1-014, L2-054 through L2-060)

### DIFF
--- a/docs/specs/L1.md
+++ b/docs/specs/L1.md
@@ -38,3 +38,8 @@ The public site shall implement a fluid, responsive layout system that adapts gr
 
 ## L1-013: Public Site Search
 The public site shall provide full-text search over published articles, modelled on the search experience of learn.microsoft.com. Search shall be accessible from a persistent input in the global header, support live autocomplete suggestions as the user types, and present results on a dedicated search results page with result cards, pagination, and an empty state. The experience shall be fully keyboard-navigable, responsive across all five breakpoints, and performant.
+
+## L1-014: Events
+**Status:** Draft
+
+The system shall allow the blog author to create, edit, publish, unpublish, and delete speaking events through the back office. Published events shall be displayed to anonymous visitors on the public site, organized by upcoming and past dates, with a detail page for each event.

--- a/docs/specs/L2.md
+++ b/docs/specs/L2.md
@@ -667,3 +667,98 @@ All search input shall be treated as untrusted user input. The query parameter s
 2. Given a query containing `" onmouseover="alert(1)`, when the results page is rendered, then no injected event handler shall execute and the query shall render as escaped text.
 3. Given a query exceeding 200 characters, when submitted to the search endpoint, then the system shall return 400 Bad Request and no search shall be performed.
 4. Given the `<title>` tag on the search results page, when inspected, then the query value shall be HTML-entity-encoded so that special characters cannot break out of the tag context.
+
+---
+
+## L2-054: Create Event
+**Status:** Draft
+**Traces to:** L1-014
+
+An authenticated user shall be able to create a new speaking event by providing a title, description, start date, optional end date, location, and optional external URL linking to the event page. The system shall generate a URL-safe slug from the title. The event shall default to unpublished (draft) status.
+
+**Acceptance Criteria:**
+1. Given an authenticated user, when they submit a valid event with title, description, start date, and location, then the event shall be persisted with a generated slug and `published = false`.
+2. Given an authenticated user, when they submit an event with a title that generates a slug already in use, then the system shall return a 409 Conflict response.
+3. Given an authenticated user, when they submit an event missing the title, start date, or location, then the system shall return a 400 Bad Request with field-level validation errors.
+4. Given an unauthenticated request, when they attempt to create an event, then the system shall return a 401 Unauthorized response.
+
+---
+
+## L2-055: Edit Event
+**Status:** Draft
+**Traces to:** L1-014
+
+An authenticated user shall be able to update any field of an existing event (title, description, start date, end date, location, external URL, published status). Updating the title shall regenerate the slug.
+
+**Acceptance Criteria:**
+1. Given an authenticated user and an existing event, when they update the title, then the slug shall be regenerated from the new title.
+2. Given an authenticated user, when they update a title that generates a slug already in use by a different event, then the system shall return a 409 Conflict response.
+3. Given an authenticated user, when they update an event with valid data, then all changed fields shall be persisted and unchanged fields shall remain intact.
+4. Given an authenticated user, when they update an event with an empty title, then the system shall return a 400 Bad Request.
+5. Given an authenticated user, when they update a non-existent event ID, then the system shall return a 404 Not Found.
+
+---
+
+## L2-056: Delete Event
+**Status:** Draft
+**Traces to:** L1-014
+
+An authenticated user shall be able to permanently delete an event. Deletion shall remove the event from the system.
+
+**Acceptance Criteria:**
+1. Given an authenticated user and an existing event, when they delete it, then the event shall no longer be retrievable via API or public site.
+2. Given an authenticated user, when they delete a non-existent event, then the system shall return 404 Not Found.
+3. Given an unauthenticated request, when they attempt to delete an event, then the system shall return 401 Unauthorized.
+
+---
+
+## L2-057: List Events in Back Office
+**Status:** Draft
+**Traces to:** L1-014
+
+The back-office shall display a paginated list of all events ordered by start date descending. The list shall include both published and unpublished events and show each event's title, start date, location, and published status.
+
+**Acceptance Criteria:**
+1. Given an authenticated user, when they navigate to the events management page, then all events shall be listed in descending start-date order with title, start date, location, and published status visible.
+2. Given more events than fit on a single page, when the user views the event list, then pagination controls shall allow navigating between pages.
+3. Given an unauthenticated request, when they attempt to access the events management page, then the system shall return 401 Unauthorized.
+
+---
+
+## L2-058: Publish and Unpublish Event
+**Status:** Draft
+**Traces to:** L1-014
+
+An authenticated user shall be able to publish a draft event (setting `published = true`) and unpublish a published event (setting `published = false`). Only published events shall appear on the public site.
+
+**Acceptance Criteria:**
+1. Given an authenticated user and a draft event, when they publish it, then `published` shall be `true` and the event shall become visible on the public site.
+2. Given an authenticated user and a published event, when they unpublish it, then `published` shall be `false` and the event shall no longer be visible on the public site.
+3. Given an unauthenticated request, when they attempt to publish or unpublish an event, then the system shall return 401 Unauthorized.
+
+---
+
+## L2-059: Public Events Display
+**Status:** Draft
+**Traces to:** L1-014
+
+The public site shall present published events on a dedicated events page accessible at `/events`. Events shall be separated into upcoming and past sections based on the event start date relative to the current date. Upcoming events shall be ordered by start date ascending (soonest first). Past events shall be ordered by start date descending (most recent first).
+
+**Acceptance Criteria:**
+1. Given published events exist with future start dates, when an anonymous visitor navigates to `/events`, then the upcoming section shall list those events in ascending start-date order.
+2. Given published events exist with past start dates, when an anonymous visitor navigates to `/events`, then the past section shall list those events in descending start-date order.
+3. Given no published events exist, when an anonymous visitor navigates to `/events`, then the page shall display an appropriate empty state message.
+4. Given a mix of published and unpublished events, when an anonymous visitor navigates to `/events`, then only published events shall be displayed.
+
+---
+
+## L2-060: Public Event Detail
+**Status:** Draft
+**Traces to:** L1-014
+
+The public site shall display a detail page for each published event at `/events/{slug}`. The detail page shall show the event title, description, start date, end date (if provided), location, and a link to the external event URL (if provided).
+
+**Acceptance Criteria:**
+1. Given a published event with a slug, when an anonymous visitor navigates to `/events/{slug}`, then the full event details shall be displayed including title, description, start date, location, and external URL (if present).
+2. Given an unpublished event, when an anonymous visitor navigates to its slug URL, then the system shall return 404 Not Found.
+3. Given a non-existent slug, when an anonymous visitor navigates to `/events/{slug}`, then the system shall return 404 Not Found.


### PR DESCRIPTION
## Summary
This PR adds comprehensive specifications for a new event management system that allows blog authors to create, manage, and publish speaking events through the back office, with public display on the site.

## Key Changes
- **L1-014 (Events)**: Added high-level epic requirement defining the event management system scope
- **L2-054 (Create Event)**: Specified event creation workflow with slug generation, validation, and draft status defaults
- **L2-055 (Edit Event)**: Defined event update capabilities including title/slug regeneration and conflict handling
- **L2-056 (Delete Event)**: Specified permanent event deletion with proper authorization checks
- **L2-057 (List Events in Back Office)**: Defined paginated event management interface for authenticated users
- **L2-058 (Publish and Unpublish Event)**: Specified publish/unpublish toggle functionality controlling public visibility
- **L2-059 (Public Events Display)**: Defined public `/events` page with upcoming/past event separation and ordering
- **L2-060 (Public Event Detail)**: Specified individual event detail pages at `/events/{slug}` with full event information

## Notable Implementation Details
- Events use URL-safe slugs generated from titles with duplicate slug conflict detection (409 Conflict)
- All event management operations require authentication (401 Unauthorized for unauthenticated requests)
- Events default to unpublished (draft) status and require explicit publishing to appear publicly
- Public event display separates upcoming (ascending date order) from past events (descending date order)
- Comprehensive field-level validation with 400 Bad Request responses for invalid data
- All specifications marked as Draft status and trace to parent epic L1-014

https://claude.ai/code/session_01RupN9t2h2i8FszspkSz6B5